### PR TITLE
Add GraphQL Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ npm start
 
 The server listens on **http://localhost:44361/graphql**.
 
+Open **http://localhost:44361/** in your browser to access GraphQL Playground
+for interactive testing.
+
 ## Project layout
 
 ```


### PR DESCRIPTION
## Summary
- serve a minimal GraphQL Playground page
- document the playground URL

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6848d720425c832c905e859d7fd816ab