### PR TITLE
Ensure playground sends mock_config cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Open this URL in your browser to access the GraphQL Playground powered by Apollo
 Server. The playground allows you to explore the schema and experiment with
 queries against the mock API.
 
+The playground is configured to send cookies with each request so the
+`mock_config` cookie set by the Chrome extension is respected when running
+queries.
+
 ## Project layout
 
 ```

--- a/server.ts
+++ b/server.ts
@@ -40,7 +40,12 @@ const baseSchema = makeExecutableSchema({ typeDefs });
 // Generate the GraphQL Playground HTML once on startup using the helper from
 // Apollo Server. The resulting page is served on GET requests so you can easily
 // explore the schema and test queries in the browser.
-const playgroundHtml = renderPlaygroundPage({ endpoint: "/graphql" });
+const playgroundHtml = renderPlaygroundPage({
+  endpoint: "/graphql",
+  // Include cookies like `mock_config` in playground requests so variant
+  // selections made by the Chrome extension reach the server.
+  settings: { "request.credentials": "include" },
+});
 
 // Scan the local mocks directory to discover which types/fields have a `0.ts`
 // mock variant. We use this information so that missing entries in config


### PR DESCRIPTION
## Summary
- configure GraphQL Playground to include credentials so cookies like `mock_config` get forwarded
- document that the playground forwards cookies

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6848dcaea450832c8124f373be165b32