### PR TITLE
Add JSON preview to Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ your GraphQL schema, adjust variant numbers in the popup and press
 **Apply**. The extension sets the cookie for the active tab based on the
 form values. Your last uploaded schema and variant selections are stored
 so reopening the popup restores them automatically.
+The popup now displays the current configuration as beautified JSON next
+to the form. Use the **Copy** button to copy the JSON to your clipboard
+for sharing or inspection.
 
 ### Passthrough example
 

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -5,6 +5,17 @@
   <title>Mock Config Editor</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 10px; }
+    #container { display: flex; align-items: flex-start; }
+    #formContainer { flex: 1; margin-right: 10px; }
+    #jsonContainer { flex: 1; }
+    #jsonOutput {
+      white-space: pre-wrap;
+      background: #f0f0f0;
+      padding: 8px;
+      overflow: auto;
+      max-height: 400px;
+      border: 1px solid #ccc;
+    }
     .field { margin-bottom: 8px; }
     .type { margin-top: 10px; font-weight: bold; }
     input[type=number] { width: 60px; }
@@ -12,7 +23,13 @@
 </head>
 <body>
   <input type="file" id="schemaFile" />
-  <div id="formContainer"></div>
+  <div id="container">
+    <div id="formContainer"></div>
+    <div id="jsonContainer">
+      <pre id="jsonOutput"></pre>
+      <button id="copyBtn">Copy</button>
+    </div>
+  </div>
   <button id="applyBtn">Apply</button>
   <script src="popup.js"></script>
 </body>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -67,6 +67,7 @@ function renderForm(schema, saved = {}) {
       input.addEventListener('input', saveConfig);
     });
   });
+  updateJsonPreview();
 }
 
 function getConfig() {
@@ -87,9 +88,17 @@ function getConfig() {
   return config;
 }
 
+function updateJsonPreview() {
+  const pre = document.getElementById('jsonOutput');
+  if (pre) {
+    pre.textContent = JSON.stringify(getConfig(), null, 2);
+  }
+}
+
 function saveConfig() {
   const config = getConfig();
   chrome.storage.local.set({ config });
+  updateJsonPreview();
 }
 
 function setCookie(config) {
@@ -121,6 +130,7 @@ document.getElementById('applyBtn').addEventListener('click', () => {
   const config = getConfig();
   chrome.storage.local.set({ config });
   setCookie(config);
+  updateJsonPreview();
 });
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -129,5 +139,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const schema = parseSchema(data.schemaText);
       renderForm(schema, data.config || {});
     }
+    updateJsonPreview();
+  });
+  document.getElementById('copyBtn').addEventListener('click', () => {
+    const text = document.getElementById('jsonOutput').textContent;
+    navigator.clipboard.writeText(text);
   });
 });


### PR DESCRIPTION
## Summary
- show configuration JSON in popup
- allow copying JSON to clipboard
- document JSON preview feature

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm start` (server started successfully)

------
https://chatgpt.com/codex/tasks/task_e_6848e580cf50832cb9c3d2c8dcad3201