### PR TITLE
Switch to Apollo Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cp config/config.example.yml config/config.yml
 npm start
 ```
 
-Open **http://localhost:4001/graphql** to explore the API in Apollo Playground.  
+Open **http://localhost:4001/graphql** to explore the API in **Apollo Sandbox**.
 Cookies are sent automatically, so the `mock_config` cookie works out of the box.
 
 > Use a watcher such as `nodemon` for live-reload if desired.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/server": "^4.12.2",
-        "@apollographql/graphql-playground-html": "^1.6.29",
         "@graphql-tools/load-files": "^7.0.1",
         "@graphql-tools/merge": "^9.0.24",
         "@graphql-tools/mock": "^9.0.23",
@@ -303,15 +302,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "license": "MIT",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1312,12 +1302,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1385,12 +1369,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -2786,22 +2764,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/xss": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
-      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@apollo/server": "^4.12.2",
-    "@apollographql/graphql-playground-html": "^1.6.29",
     "@graphql-tools/load-files": "^7.0.1",
     "@graphql-tools/merge": "^9.0.24",
     "@graphql-tools/mock": "^9.0.23",


### PR DESCRIPTION
## Summary
- remove Apollo Playground dependency
- embed Apollo Sandbox as landing page
- update README accordingly

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm start` (fails until config copied)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685122b1fe60832c9fa1d53a63f6404a